### PR TITLE
[[Bug 18305]] update dictionary search

### DIFF
--- a/Documentation/html_viewer/js/dictionary_functions.js
+++ b/Documentation/html_viewer/js/dictionary_functions.js
@@ -29,7 +29,7 @@
 	// as a (matchable) string
 	function collectSyntax(pEntry)
 	{
-		var tSyntax = '';
+		var tSyntax = pEntry["display name"];
 		$.each(pEntry["display syntax"], function (index, value) 
 		{
 			if (tSyntax != '')


### PR DESCRIPTION
Update the dictionary search to also consider the "display name" field.  Pull request #5669 on livecode/livecode is also needed to resolve the bug.  That request will add the synonyms to the dictionary cache, this one makes them visible to the search.